### PR TITLE
REFACTOR: streamline table/callout/element code in translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.1 (2025-01-11)
+
+Refactor the MD parser, internally adding a `Container` enum that encapsulates behaviour of
+more complex MD elements which can have children.
+
 ## v0.3.0 (2025-01-02)
 
 Add support for **raw HTML** in the MD parser.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macros"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [lib]

--- a/markdown/Cargo.toml
+++ b/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/markdown/src/translate.rs
+++ b/markdown/src/translate.rs
@@ -1,4 +1,5 @@
 pub mod complex;
+pub mod container;
 pub mod element;
 pub mod error;
 pub mod node;

--- a/markdown/src/translate/complex.rs
+++ b/markdown/src/translate/complex.rs
@@ -1,2 +1,1 @@
 pub mod footnotes;
-pub mod table;

--- a/markdown/src/translate/container.rs
+++ b/markdown/src/translate/container.rs
@@ -1,0 +1,1 @@
+pub mod callout;

--- a/markdown/src/translate/container.rs
+++ b/markdown/src/translate/container.rs
@@ -1,1 +1,49 @@
+use std::fmt::Display;
+
+use callout::Callout;
+
+use super::{element::{ElementTag, RenderElement}, node::RenderNode};
+
 pub mod callout;
+
+pub enum Container {
+    Element(RenderElement),
+    Callout(Callout),
+}
+
+impl Container {
+    pub fn add_child(&mut self, child: RenderNode) {
+        match self {
+            Container::Element(element) => element.add_child(child),
+            Container::Callout(callout) => callout.add_child(child),
+        }
+    }
+}
+
+impl From<Container> for RenderNode {
+    fn from(value: Container) -> Self {
+        match value {
+            Container::Element(element) => element.into(),
+            Container::Callout(callout) => callout.into(),
+        }
+    }
+}
+
+// OVERARCHING TAG DATA TYPE
+
+#[derive(Debug, Clone)]
+pub enum ContainerTag {
+    Element(ElementTag),
+    Callout,
+}
+
+impl Display for ContainerTag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let formatted = match self {
+            ContainerTag::Element(tag) => &tag.to_string(),
+            ContainerTag::Callout => "callout",
+        };
+
+        write!(f, "{}", formatted)
+    }
+}

--- a/markdown/src/translate/container.rs
+++ b/markdown/src/translate/container.rs
@@ -1,14 +1,20 @@
 use std::fmt::Display;
 
 use callout::Callout;
+use table::Table;
 
-use super::{element::{ElementTag, RenderElement}, node::RenderNode};
+use super::{
+    element::{ElementTag, RenderElement},
+    node::RenderNode,
+};
 
 pub mod callout;
+pub mod table;
 
 pub enum Container {
     Element(RenderElement),
     Callout(Callout),
+    Table(Table),
 }
 
 impl Container {
@@ -16,6 +22,7 @@ impl Container {
         match self {
             Container::Element(element) => element.add_child(child),
             Container::Callout(callout) => callout.add_child(child),
+            Container::Table(table) => table.add_child(child),
         }
     }
 }
@@ -25,6 +32,7 @@ impl From<Container> for RenderNode {
         match value {
             Container::Element(element) => element.into(),
             Container::Callout(callout) => callout.into(),
+            Container::Table(table) => table.into(),
         }
     }
 }
@@ -35,6 +43,7 @@ impl From<Container> for RenderNode {
 pub enum ContainerTag {
     Element(ElementTag),
     Callout,
+    Table,
 }
 
 impl Display for ContainerTag {
@@ -42,6 +51,7 @@ impl Display for ContainerTag {
         let formatted = match self {
             ContainerTag::Element(tag) => &tag.to_string(),
             ContainerTag::Callout => "callout",
+            ContainerTag::Table => "table",
         };
 
         write!(f, "{}", formatted)

--- a/markdown/src/translate/container/callout.rs
+++ b/markdown/src/translate/container/callout.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::translate::node::RenderNode;
 
+use super::Container;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CalloutKind {
     Note,
@@ -40,5 +42,17 @@ impl Callout {
 
     pub fn add_child(&mut self, child: RenderNode) {
         self.children.push(child)
+    }
+}
+
+impl From<Callout> for RenderNode {
+    fn from(value: Callout) -> Self {
+        RenderNode::Callout(value)
+    }
+}
+
+impl From<Callout> for Container {
+    fn from(value: Callout) -> Self {
+        Container::Callout(value)
     }
 }

--- a/markdown/src/translate/container/callout.rs
+++ b/markdown/src/translate/container/callout.rs
@@ -1,0 +1,44 @@
+use pulldown_cmark::BlockQuoteKind;
+use serde::{Deserialize, Serialize};
+
+use crate::translate::node::RenderNode;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CalloutKind {
+    Note,
+    Tip,
+    Important,
+    Warning,
+    Caution,
+}
+
+impl From<BlockQuoteKind> for CalloutKind {
+    fn from(value: BlockQuoteKind) -> Self {
+        match value {
+            BlockQuoteKind::Note => CalloutKind::Note,
+            BlockQuoteKind::Tip => CalloutKind::Tip,
+            BlockQuoteKind::Important => CalloutKind::Important,
+            BlockQuoteKind::Warning => CalloutKind::Warning,
+            BlockQuoteKind::Caution => CalloutKind::Caution,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Callout {
+    pub kind: CalloutKind,
+    pub children: Vec<RenderNode>,
+}
+
+impl Callout {
+    pub fn new(kind: CalloutKind) -> Self {
+        Self {
+            kind,
+            children: vec![],
+        }
+    }
+
+    pub fn add_child(&mut self, child: RenderNode) {
+        self.children.push(child)
+    }
+}

--- a/markdown/src/translate/element.rs
+++ b/markdown/src/translate/element.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use pulldown_cmark::HeadingLevel;
 use serde::{Deserialize, Serialize};
 
-use super::node::RenderNode;
+use super::{container::Container, node::RenderNode};
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum ElementTag {
@@ -146,5 +146,17 @@ impl RenderElement {
 
     pub fn add_child(&mut self, child: RenderNode) {
         self.children.push(child)
+    }
+}
+
+impl From<RenderElement> for RenderNode {
+    fn from(value: RenderElement) -> Self {
+        RenderNode::Element(value)
+    }
+}
+
+impl From<RenderElement> for Container {
+    fn from(value: RenderElement) -> Self {
+        Container::Element(value)
     }
 }

--- a/markdown/src/translate/error.rs
+++ b/markdown/src/translate/error.rs
@@ -12,7 +12,6 @@ pub enum TranslateError {
         tags: Vec<ContainerTag>,
     },
     CalloutError,
-    RawHtmlError,
     TableMergeError,
 }
 
@@ -33,7 +32,6 @@ impl Display for TranslateError {
                 format!("None of the tags {} matched", tags_str)
             }
             Self::CalloutError => "Expected callout".to_string(),
-            Self::RawHtmlError => "Expected raw HTML".to_string(),
             Self::TableMergeError => "Invalid merge command".to_string(),
         };
 

--- a/markdown/src/translate/error.rs
+++ b/markdown/src/translate/error.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::{element::ElementTag, node::RenderTag};
+use super::{container::ContainerTag, element::ElementTag};
 
 #[derive(Debug, Clone)]
 pub enum TranslateError {
@@ -9,7 +9,7 @@ pub enum TranslateError {
         result: Option<ElementTag>,
     },
     NoMatchError {
-        tags: Vec<RenderTag>,
+        tags: Vec<ContainerTag>,
     },
     CalloutError,
     RawHtmlError,

--- a/markdown/src/translate/node.rs
+++ b/markdown/src/translate/node.rs
@@ -1,11 +1,6 @@
-use std::fmt::Display;
-
 use serde::{Deserialize, Serialize};
 
-use super::{
-    container::callout::Callout,
-    element::{ElementTag, RenderElement},
-};
+use super::{container::callout::Callout, element::RenderElement};
 
 // HTML
 
@@ -50,38 +45,5 @@ impl From<RenderHtml> for RenderNode {
 impl From<RenderIcon> for RenderNode {
     fn from(value: RenderIcon) -> Self {
         RenderNode::Icon(value)
-    }
-}
-
-impl From<RenderElement> for RenderNode {
-    fn from(value: RenderElement) -> Self {
-        RenderNode::Element(value)
-    }
-}
-
-impl From<Callout> for RenderNode {
-    fn from(value: Callout) -> Self {
-        RenderNode::Callout(value)
-    }
-}
-
-// OVERARCHING TAG DATA TYPE
-
-#[derive(Debug, Clone)]
-pub enum RenderTag {
-    Element(ElementTag),
-    Callout,
-    Html,
-}
-
-impl Display for RenderTag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let formatted = match self {
-            RenderTag::Element(tag) => &tag.to_string(),
-            RenderTag::Callout => "callout",
-            RenderTag::Html => "html",
-        };
-
-        write!(f, "{}", formatted)
     }
 }

--- a/markdown/src/translate/node.rs
+++ b/markdown/src/translate/node.rs
@@ -1,9 +1,11 @@
 use std::fmt::Display;
 
-use pulldown_cmark::BlockQuoteKind;
 use serde::{Deserialize, Serialize};
 
-use super::element::{ElementTag, RenderElement};
+use super::{
+    container::callout::Callout,
+    element::{ElementTag, RenderElement},
+};
 
 // HTML
 
@@ -21,48 +23,6 @@ pub enum RenderIcon {
     Caution,
 }
 
-// CALLOUTS
-
-#[derive(Debug, Serialize, Deserialize)]
-pub enum CalloutKind {
-    Note,
-    Tip,
-    Important,
-    Warning,
-    Caution,
-}
-
-impl From<BlockQuoteKind> for CalloutKind {
-    fn from(value: BlockQuoteKind) -> Self {
-        match value {
-            BlockQuoteKind::Note => CalloutKind::Note,
-            BlockQuoteKind::Tip => CalloutKind::Tip,
-            BlockQuoteKind::Important => CalloutKind::Important,
-            BlockQuoteKind::Warning => CalloutKind::Warning,
-            BlockQuoteKind::Caution => CalloutKind::Caution,
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RenderCallout {
-    pub kind: CalloutKind,
-    pub children: Vec<RenderNode>,
-}
-
-impl RenderCallout {
-    pub fn new(kind: CalloutKind) -> Self {
-        Self {
-            kind,
-            children: vec![],
-        }
-    }
-
-    pub fn add_child(&mut self, child: RenderNode) {
-        self.children.push(child)
-    }
-}
-
 // OVERARCHING NODE DATA TYPE
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -72,7 +32,7 @@ pub enum RenderNode {
     Icon(RenderIcon),
     Element(RenderElement),
     // Separate member because we want them to appear outside of <article>
-    Callout(RenderCallout),
+    Callout(Callout),
 }
 
 impl From<String> for RenderNode {
@@ -99,8 +59,8 @@ impl From<RenderElement> for RenderNode {
     }
 }
 
-impl From<RenderCallout> for RenderNode {
-    fn from(value: RenderCallout) -> Self {
+impl From<Callout> for RenderNode {
+    fn from(value: Callout) -> Self {
         RenderNode::Callout(value)
     }
 }

--- a/markdown/src/translate/translator.rs
+++ b/markdown/src/translate/translator.rs
@@ -4,9 +4,10 @@ use crate::structs::metadata::PostTranslateData;
 
 use super::{
     complex::{footnotes::Footnotes, table::Table},
+    container::callout::Callout,
     element::{AttributeName, ElementTag, RenderElement},
     error::TranslateError,
-    node::{RenderCallout, RenderHtml, RenderNode, RenderTag},
+    node::{RenderHtml, RenderNode, RenderTag},
 };
 
 pub struct TranslateOutput {
@@ -200,7 +201,7 @@ where
     }
 
     fn generate_callout(&mut self, kind: BlockQuoteKind) {
-        let callout = RenderCallout::new(kind.into());
+        let callout = Callout::new(kind.into());
         self.enter(callout);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hanyuone.live",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A personal website written in Rust.",
   "main": "index.js",
   "scripts": {

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "website"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [features]

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hanyuone.live",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/website/src/components/blog_post/callout.rs
+++ b/website/src/components/blog_post/callout.rs
@@ -1,4 +1,4 @@
-use markdown::translate::node::CalloutKind;
+use markdown::translate::container::callout::CalloutKind;
 use yew::{classes, function_component, html, props, Children, Html, Properties};
 use yew_icons::{Icon, IconId};
 

--- a/website/src/render.rs
+++ b/website/src/render.rs
@@ -1,6 +1,7 @@
 use markdown::translate::{
+    container,
     element::RenderElement,
-    node::{RenderCallout, RenderIcon, RenderNode},
+    node::{RenderIcon, RenderNode},
 };
 use yew::{
     html,
@@ -73,7 +74,7 @@ impl Renderer {
 
                 tag.into()
             }
-            RenderNode::Callout(RenderCallout { kind, children }) => {
+            RenderNode::Callout(container::callout::Callout { kind, children }) => {
                 let props = kind.into();
                 let children = Renderer::new().run(children);
 


### PR DESCRIPTION
This PR acts as preparation for the addition of *code blocks*. Rewrite `translator.rs` and surrounds, creating a new enum `Container` which encapsulates the behaviour of all "containers" - components that are more complicated than a base HTML element in some way, and which can have children.