### PR TITLE
REFACTOR: improve error handling in `Translator`

### DIFF
--- a/markdown/src/main.rs
+++ b/markdown/src/main.rs
@@ -44,7 +44,10 @@ fn create_blog_files(content_dir: &str) -> io::Result<Vec<BlogFile>> {
         let TranslateOutputBytes {
             bytes,
             post_translate,
-        } = to_bytestring(&content);
+        } = match to_bytestring(&content) {
+            Ok(output) => output,
+            Err(err) => panic!("{}", err),
+        };
 
         let filename = entry
             .path()

--- a/markdown/src/translate.rs
+++ b/markdown/src/translate.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod node;
 pub mod translator;
 
+use error::TranslateError;
 use pulldown_cmark::{Options, Parser};
 use translator::{TranslateOutput, Translator};
 
@@ -15,16 +16,16 @@ pub struct TranslateOutputBytes {
     pub post_translate: PostTranslateData,
 }
 
-pub fn to_bytestring(raw: &str) -> TranslateOutputBytes {
+pub fn to_bytestring(raw: &str) -> Result<TranslateOutputBytes, TranslateError> {
     let parser = Parser::new_ext(raw, Options::all());
     let translator = Translator::new(parser);
     let TranslateOutput {
         nodes,
         post_translate,
-    } = translator.run();
+    } = translator.run()?;
 
-    TranslateOutputBytes {
+    Ok(TranslateOutputBytes {
         bytes: ron::to_string(&nodes).expect("encoded nodes into bytestring"),
         post_translate,
-    }
+    })
 }

--- a/markdown/src/translate/container/table.rs
+++ b/markdown/src/translate/container/table.rs
@@ -333,23 +333,19 @@ impl Table {
 
         Ok(())
     }
-
-    pub fn to_node(self) -> RenderNode {
-        let mut table_element = RenderElement::new(ElementTag::Table);
-
-        let table_head = self.head.into_node(&self.alignment);
-        table_element.add_child(table_head);
-
-        let table_body = self.body.into_node(&self.alignment);
-        table_element.add_child(table_body);
-
-        table_element.into()
-    }
 }
 
 impl From<Table> for RenderNode {
     fn from(value: Table) -> Self {
-        value.to_node()
+        let mut table_element = RenderElement::new(ElementTag::Table);
+
+        let table_head = value.head.into_node(&value.alignment);
+        table_element.add_child(table_head);
+
+        let table_body = value.body.into_node(&value.alignment);
+        table_element.add_child(table_body);
+
+        table_element.into()
     }
 }
 

--- a/markdown/src/translate/container/table.rs
+++ b/markdown/src/translate/container/table.rs
@@ -101,8 +101,14 @@ impl Chunk {
 
     // Chunk helper functions
 
+    
     /// Returns the current position of the cell we're adding.
     /// Call when we're fetching cells from the parser.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.cells` is empty, i.e. there are no rows, which
+    /// should not be possible.
     fn current_position(&self) -> CellPosition {
         CellPosition(
             self.cells.len() as isize - 1,
@@ -123,7 +129,12 @@ impl Chunk {
         self.cells.push(vec![]);
     }
 
-    /// Given a "wrapped" cell, adds it to the last row.
+    /// Given a "wrapped" cell, adds it to the last row. Only called after
+    /// a row is initialised through `Chunk::add_row`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self.cells` is empty (which should not be possible).
     fn add_cell(&mut self, cell: Cell) {
         self.cells.last_mut().unwrap().push(cell);
     }
@@ -138,14 +149,14 @@ impl Chunk {
     /// This function will return an error if we have merging that results in
     /// non-rectangular cells.
     fn add_contents(&mut self, content: Vec<RenderNode>) -> Result<(), TranslateError> {
-        let merge_dir = MergeDirection::extract_from_nodes(&content);
+        let merge_dir = match MergeDirection::extract_from_nodes(&content) {
+            Some(merge_dir) => merge_dir,
+            None => {
+                self.add_cell(Cell::Content(content));
+                return Ok(());
+            }
+        };
 
-        if merge_dir.is_none() {
-            self.add_cell(Cell::Content(content));
-            return Ok(());
-        }
-
-        let merge_dir = merge_dir.unwrap();
         let curr_pos = self.current_position();
 
         let target_pos = curr_pos
@@ -172,6 +183,9 @@ impl Chunk {
             }
             Cell::Pointer(origin) => {
                 let origin = *origin;
+                // Guaranteed to exist in `self.merged_sizes` since the pointer
+                // at the target cell *must* point towards the top-left cell in the
+                // block, which is added through the `Cell::Content` match arm
                 let existing_size = self.merged_sizes.get(&origin).unwrap();
 
                 let new_dimensions = match merge_dir {

--- a/markdown/src/translate/error.rs
+++ b/markdown/src/translate/error.rs
@@ -12,6 +12,9 @@ pub enum TranslateError {
         tags: Vec<ContainerTag>,
     },
     CalloutError,
+    FootnoteError {
+        name: String,
+    },
     TableMergeError,
 }
 
@@ -32,6 +35,7 @@ impl Display for TranslateError {
                 format!("None of the tags {} matched", tags_str)
             }
             Self::CalloutError => "Expected callout".to_string(),
+            Self::FootnoteError { name } => format!("Footnote \"{}\" does not exist", name),
             Self::TableMergeError => "Invalid merge command".to_string(),
         };
 

--- a/markdown/src/translate/translator.rs
+++ b/markdown/src/translate/translator.rs
@@ -463,7 +463,15 @@ where
                 let mut anchor = RenderElement::new(ElementTag::A);
                 anchor.add_attribute(AttributeName::Href, format!("#footnote_{name}"));
 
-                let index = self.footnotes.get_index(name).unwrap();
+                let index = match self.footnotes.get_index(name.clone()) {
+                    Some(index) => index,
+                    None => {
+                        return Err(TranslateError::FootnoteError {
+                            name: name.to_string(),
+                        })
+                    }
+                };
+
                 anchor.add_child(format!("{index}").into());
 
                 sup.add_child(RenderNode::Element(anchor));


### PR DESCRIPTION
Improves overall error handling in `Translator`, especially for tables. This includes:
- Removing as many `.unwrap()` calls as possible
- Justifying any remaining "justified" `.unwrap()` calls in comments
- Bubbling up errors through `Result` as much as possible