### PR TITLE
FEATURE: add maths support in Markdown engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.5.0 (2025-02-12)
+
+Add support for **inline** and **display maths blocks** with the help of MathJax. When translating
+from Markdown into HTML, uses MathJax 2 syntax (i.e. matching on `<script type="math/tex" />` instead
+on raw dollar-signs).
+
 ## v0.4.0 (2025-01-31)
 
 Add support for **inline code** and **code blocks** (including **syntax highlighting**).

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/markdown/Cargo.toml
+++ b/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]

--- a/markdown/src/translate/element.rs
+++ b/markdown/src/translate/element.rs
@@ -27,6 +27,7 @@ pub enum ElementTag {
     Ol,
     P,
     Pre,
+    Script,
     Span,
     Strong,
     Sup,
@@ -62,6 +63,7 @@ impl Display for ElementTag {
             Self::Ol => "ol",
             Self::P => "p",
             Self::Pre => "pre",
+            Self::Script => "script",
             Self::Span => "span",
             Self::Strong => "strong",
             Self::Sup => "sup",
@@ -99,11 +101,13 @@ pub enum AttributeName {
     Colspan,
     Href,
     Id,
+    Mode,
     Rowspan,
     Src,
     Start,
     Style,
     Title,
+    Type,
 }
 
 impl From<AttributeName> for &'static str {
@@ -115,11 +119,13 @@ impl From<AttributeName> for &'static str {
             AttributeName::Colspan => "colspan",
             AttributeName::Href => "href",
             AttributeName::Id => "id",
+            AttributeName::Mode => "mode",
             AttributeName::Rowspan => "rowspan",
             AttributeName::Src => "src",
             AttributeName::Start => "start",
             AttributeName::Style => "style",
             AttributeName::Title => "title",
+            AttributeName::Type => "type",
         }
     }
 }

--- a/markdown/src/translate/translator.rs
+++ b/markdown/src/translate/translator.rs
@@ -438,6 +438,23 @@ where
                 self.output(code)
             }
 
+            // === Maths ===
+            Event::DisplayMath(text) => {
+                let mut display_math = RenderElement::new(ElementTag::Script);
+                display_math.add_attribute(AttributeName::Type, "math/tex".to_string());
+                display_math.add_attribute(AttributeName::Mode, "display".to_string());
+
+                display_math.add_child(RenderNode::Text(text.into_string()));
+                self.output(display_math)
+            },
+            Event::InlineMath(text) => {
+                let mut inline_math = RenderElement::new(ElementTag::Script);
+                inline_math.add_attribute(AttributeName::Type, "math/tex".to_string());
+
+                inline_math.add_child(RenderNode::Text(text.into_string()));
+                self.output(inline_math)
+            },
+
             // === Line breaks ===
             Event::SoftBreak => self.output("\n".to_string()),
             Event::HardBreak => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hanyuone.live",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "A personal website written in Rust.",
   "main": "index.js",
   "scripts": {

--- a/public/blog/ductf_2021_writeup.md
+++ b/public/blog/ductf_2021_writeup.md
@@ -55,25 +55,33 @@ format:    DUCTF{.................}
 
 Because the cipher is one-to-one, `D` maps to `U`, `U` maps to `j`, and so on. Based on the indices of these characters in `CHARSET`, we know that `f(0) = 1`, `f(1) = 20`... `f(6) = 41`. We now have our 7 simultaneous equations:
 
-```
-                                 g =  1 (1)
-  a +   b +   c +  d +  e +  f + g = 20 (2)
-64a + 32b + 16c + 8d + 4e + 2f + g = 35 (3)
-...
-```
+$$
+\begin{align}
+                                 g &=  1, \\
+  a +   b +   c +  d +  e +  f + g &= 20, \\
+64a + 32b + 16c + 8d + 4e + 2f + g &= 35, \\
+&\cdots
+\end{align}
+$$
 
 We can create a matrix representation of these simultaneous equations, and now we need to solve for `x`:
 
-```
-[  0  0  0 0 0 0 1 ]     [  1 ]
-[  1  1  1 1 1 1 1 ] x = [ 20 ]
-[ 64 32 16 8 4 2 1 ]     [ 35 ]
-...                      ...
-```
+$$
+\begin{bmatrix}
+0 & 0 & 0 & 0 & 0 & 0 & 1 \\
+1 & 1 & 1 & 1 & 1 & 1 & 1 \\
+64 & 32 & 16 & 8 & 4 & 2 & 1 \\
+& & & \vdots & & &
+\end{bmatrix}
+x =
+\begin{bmatrix}
+1 \\ 20 \\ 35 \\ \vdots
+\end{bmatrix}
+$$
 
 Plugging the matrix and column vector into Maple and solving for `x`, `x` is equal to the column vector `<37/80, -633/80, 2437/48, -7229/48, 5963/30, -4349/60, 1>`, which is equivalent to `<41, 15, 40, 9, 28, 27, 1>` mod 47.
 
-Thus, our random polynomial, `f`, is `41x^6 + 15x^5 + 40x^4 + 9x^3 + 28x^2 + 27x + 1`.
+Thus, our random polynomial, `f`, is $41x^6 + 15x^5 + 40x^4 + 9x^3 + 28x^2 + 27x + 1$.
 
 ## Final solution:
 

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "website"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [features]

--- a/website/index.html
+++ b/website/index.html
@@ -1,22 +1,43 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/tailwind.css" />
-    <link rel="icon" data-trunk href="/favicon.ico" />
 
-    <script id="head-ssg-before"></script>
-    <script id="head-ssg-after"></script>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/tailwind.css" />
+  <link rel="icon" data-trunk href="/favicon.ico" />
 
-    <link
-      data-trunk
-      rel="rust"
-      data-bin="csr"
-      data-type="main"
-      data-wasm-opt="z"
-    />
-    <link data-trunk rel="copy-dir" href="./public" />
-  </head>
-  <body></body>
+  <!-- MathJax support -->
+  <script>
+    MathJax = {
+      options: {
+        renderActions: {
+          find: [10, function (doc) {
+            for (const node of document.querySelectorAll('script[type^="math/tex"]')) {
+              const display = !!node.type.match(/; *mode=display/);
+              const math = new doc.options.MathItem(node.textContent, doc.inputJax[0], display);
+              const text = document.createTextNode('');
+              node.parentNode.replaceChild(text, node);
+              math.start = { node: text, delim: '', n: 0 };
+              math.end = { node: text, delim: '', n: 0 };
+              doc.math.push(math);
+            }
+          }, '']
+        }
+      }
+    };
+  </script>
+  <script id="MathJax-script" async
+    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+  </script>
+
+  <script id="head-ssg-before"></script>
+  <script id="head-ssg-after"></script>
+
+  <link data-trunk rel="rust" data-bin="csr" data-type="main" data-wasm-opt="z" />
+  <link data-trunk rel="copy-dir" href="./public" />
+</head>
+
+<body></body>
+
 </html>

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hanyuone.live",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Add support for rendering maths (using `$` for inline and `$$` for display) using MathJax. Under-the-hood, uses MathJax 2 syntax (i.e. matching on `<script type="math/tex">` instead of dollar-signs).