### PR TITLE
FEATURE: support mobile view (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,35 @@
 # Changelog
 
+## v0.6.0 (2025-06-28)
+
+Added support for **mobile devices**.
+
 ## v0.5.1 (2025-04-10)
 
 Added a basic background to the main page.
 
 ## v0.5.0 (2025-02-12)
 
-Add support for **inline** and **display maths blocks** with the help of MathJax. When translating
+Added support for **inline** and **display maths blocks** with the help of MathJax. When translating
 from Markdown into HTML, uses MathJax 2 syntax (i.e. matching on `<script type="math/tex" />` instead
 on raw dollar-signs).
 
 ## v0.4.0 (2025-01-31)
 
-Add support for **inline code** and **code blocks** (including **syntax highlighting**).
+Added support for **inline code** and **code blocks** (including **syntax highlighting**).
 
 ## v0.3.1 (2025-01-11)
 
-Refactor the MD parser, internally adding a `Container` enum that encapsulates behaviour of
+Refactored the MD parser, internally adding a `Container` enum that encapsulates behaviour of
 more complex MD elements which can have children.
 
 ## v0.3.0 (2025-01-02)
 
-Add support for **raw HTML** in the MD parser.
+Added support for **raw HTML** in the MD parser.
 
 ## v0.2.0 (2025-01-01)
 
-Implement **tables** in the MD parser. This includes:
+Implemented **tables** in the MD parser. This includes:
 - **Cell merging**, using `<` and `^` to merge with the cell to the left and above respectively
 - **Parse errors** when non-rectangular shapes are created as a result of cell merging
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macros"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/markdown/Cargo.toml
+++ b/markdown/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hanyuone.live",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A personal website written in Rust.",
   "main": "index.js",
   "scripts": {

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "website"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 
 [features]

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -47,6 +47,7 @@ features = [
     "BootstrapLinkedin",
     "BootstrapXOctagonFill",
     "LucideMail",
+    "LucideMenu",
 ]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hanyuone.live",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/website/src/components/blog/card.rs
+++ b/website/src/components/blog/card.rs
@@ -38,9 +38,9 @@ pub fn blog_card(props: &BlogCardProps) -> Html {
                 <p class="flex grow">{&front_matter.description}</p>
                 <div class="inline">
                     <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
-                    <span class="px-0.5 text-white">{"·"}</span>
+                    <span class="px-1 text-white">{"·"}</span>
                     <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>
-                    <span class="px-0.5 text-white">{"·"}</span>
+                    <span class="px-1 text-white">{"·"}</span>
                     {
                         front_matter.tags
                             .iter()

--- a/website/src/components/blog/card.rs
+++ b/website/src/components/blog/card.rs
@@ -25,18 +25,18 @@ pub fn blog_card(props: &BlogCardProps) -> Html {
     } = &props.metadata;
 
     html! {
-        <div class="flex flex-row hover:bg-gray">
-            <div class="flex-col basis-1/4 p-4">
+        <div class="flex flex-col md:flex-row hover:bg-gray">
+            <div class="flex-col w-full md:basis-1/4 p-4">
                 <img
                     src={front_matter.image.clone()}
                     class="aspect-video object-cover" />
             </div>
-            <div class="flex flex-col basis-3/4 p-4">
+            <div class="flex flex-col md:basis-3/4 p-4">
                 <Link<Route> to={Route::BlogPost { blog_id: props.id }}>
                     <h2 class="font-bold text-2xl hover:underline">{&front_matter.title}</h2>
                 </Link<Route>>
                 <p class="flex grow">{&front_matter.description}</p>
-                <div class="flex flex-row">
+                <div class="inline">
                     <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
                     <span class="px-0.5 text-white">{"·"}</span>
                     <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>

--- a/website/src/components/blog/item.rs
+++ b/website/src/components/blog/item.rs
@@ -31,7 +31,7 @@ pub fn blog_item(props: &BlogItemProps) -> Html {
             <Link<Route> to={Route::BlogPost { blog_id: props.id }}>
                 <h3 class="font-bold text-xl hover:underline">{&front_matter.title}</h3>
             </Link<Route>>
-            <div class="flex flex-row">
+            <div class="inline">
                 <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
                 <span class="px-0.5 text-white">{" · "}</span>
                 <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>

--- a/website/src/components/blog/item.rs
+++ b/website/src/components/blog/item.rs
@@ -33,9 +33,9 @@ pub fn blog_item(props: &BlogItemProps) -> Html {
             </Link<Route>>
             <div class="inline">
                 <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
-                <span class="px-0.5 text-white">{" · "}</span>
+                <span class="px-1 text-white">{"·"}</span>
                 <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>
-                <span class="px-0.5 text-white">{" · "}</span>
+                <span class="px-1 text-white">{"·"}</span>
                 {
                     front_matter.tags
                         .iter()

--- a/website/src/components/blog/tag.rs
+++ b/website/src/components/blog/tag.rs
@@ -1,5 +1,5 @@
 use markdown::structs::tag::TagId;
-use yew::{function_component, html, Html, Properties};
+use yew::{classes, function_component, html, Html, Properties};
 use yew_router::prelude::Link;
 
 use crate::pages::Route;
@@ -13,7 +13,7 @@ pub struct TagProps {
 #[function_component(Tag)]
 pub fn tag(props: &TagProps) -> Html {
     html! {
-        <Link<Route> to={Route::Tag { tag_id: props.name.parse::<TagId>().unwrap() }}>
+        <Link<Route> to={Route::Tag { tag_id: props.name.parse::<TagId>().unwrap() }} classes={classes!("inline-flex")}>
             <div class={format!("rounded-sm mr-1 px-1 transition bg-{0}/50 hover:bg-{0}", props.colour)}>
                 {props.name.clone()}
             </div>

--- a/website/src/components/home/typewriter.rs
+++ b/website/src/components/home/typewriter.rs
@@ -36,12 +36,12 @@ pub fn typewriter(props: &TypewriterProps) -> Html {
 
     {
         let on_finish = props.on_finish.clone();
-        let index_clone = index.clone();
+        let index = index.clone();
 
         use_interval(
             move || {
-                if *index_clone < length {
-                    index_clone.set(*index_clone + 1);
+                if *index < length {
+                    index.set(*index + 1);
                 } else {
                     on_finish.emit(());
                 }
@@ -51,7 +51,7 @@ pub fn typewriter(props: &TypewriterProps) -> Html {
     }
 
     html! {
-        <div class="flex flex-row">
+        <p>
             {
                 display_list
                     .iter()
@@ -68,12 +68,11 @@ pub fn typewriter(props: &TypewriterProps) -> Html {
                         };
 
                         html_nested! {
-                            <p class={block.class.to_string()}>{display_text}</p>
+                            <span class={block.class.to_string()}>{display_text}</span>
                         }
                     })
                     .collect::<Vec<_>>()
             }
-            <div class="w-1 h-8 animate-blink" />
-        </div>
+        </p>
     }
 }

--- a/website/src/components/layout/header.rs
+++ b/website/src/components/layout/header.rs
@@ -1,4 +1,4 @@
-use yew::{function_component, html, Html};
+use yew::{classes, function_component, html, use_state, Callback, Html};
 use yew_icons::{Icon, IconId};
 use yew_router::prelude::Link;
 
@@ -6,9 +6,80 @@ use crate::pages::Route;
 
 #[function_component(Header)]
 pub fn header() -> Html {
+    let hamburger_open = use_state(|| false);
+
+    let mut hamburger_classes = classes!(
+        "absolute",
+        "top-14",
+        "w-full",
+        "px-4",
+        "bg-black",
+        "flex",
+        "flex-col",
+        "transition",
+        "duration-200",
+        "ease-in-out",
+        "text-right",
+    );
+
+    let open_classes = if *hamburger_open {
+        classes!("opacity-100", "translate-y-0")
+    } else {
+        classes!("opacity-0", "translate-y-1")
+    };
+
+    hamburger_classes.extend(open_classes);
+
     html! {
         <nav>
-            <div class="flex flex-row mx-4 border-b-[1px] border-white">
+            // Mobile view
+            <div class="md:hidden flex flex-row mx-4 border-b-[1px] border-white">
+                <div class="flex">
+                    <Link<Route> classes="px-4 py-4 font-mono hover:bg-gray transition-colors" to={Route::Home}>
+                        {"hanyuone.live"}
+                    </Link<Route>>
+                </div>
+                <div class="flex px-4 py-4 ml-auto items-center">
+                    <button class="text-neutral-200" onclick={
+                        let hamburger_open = hamburger_open.clone();
+                        Callback::from(move |_| {
+                            hamburger_open.set(!(*hamburger_open));
+                        })
+                    }>
+                        <Icon icon_id={IconId::LucideMenu} height="1.1em" />
+                    </button>
+                </div>
+            </div>
+            // Mobile hamburger menu
+            <div class={hamburger_classes}>
+                <Link<Route> classes="w-full py-2 text-white hover:bg-blue transition-colors" to={Route::Blog}>
+                    {"Blog"}
+                </Link<Route>>
+                <a
+                    href="/public/resume.pdf"
+                    class="w-full py-2 text-white hover:bg-blue transition-colors">
+                    {"Resume"}
+                </a>
+                <div class="flex items-center justify-end">
+                    <a
+                        href="https://github.com/hanyuone"
+                        class="pr-4 py-2 text-neutral-200 hover:text-purple transition-colors">
+                        <Icon icon_id={IconId::BootstrapGithub} height="1.1em" />
+                    </a>
+                    <a
+                        href="https://linkedin.com/in/hanyuan-li"
+                        class="pr-4 py-2 text-neutral-200 hover:text-blue transition-colors">
+                        <Icon icon_id={IconId::BootstrapLinkedin} height="1.1em" />
+                    </a>
+                    <a
+                        href="mailto:work@hanyuone.live"
+                        class="py-2 text-neutral-200 hover:text-yellow transition-colors">
+                        <Icon icon_id={IconId::LucideMail} height="1.1em" />
+                    </a>
+                </div>
+            </div>
+            // Desktop view
+            <div class="hidden md:flex flex-row mx-4 border-b-[1px] border-white">
                 // Home page link
                 <div class="flex">
                     <Link<Route> classes="px-4 py-4 font-mono hover:bg-gray transition-colors" to={Route::Home}>
@@ -45,6 +116,7 @@ pub fn header() -> Html {
                     </a>
                 </div>
             </div>
+
         </nav>
     }
 }

--- a/website/src/pages/blog_post.rs
+++ b/website/src/pages/blog_post.rs
@@ -58,7 +58,7 @@ pub fn page(props: &BlogPostProps) -> Html {
             <Head>
                 <title>{format!("{} | Hanyuan's Website", title)}</title>
             </Head>
-            <div class="w-full p-4 content-center text-center border-b-[1px]">
+            <div class="flex flex-col p-4 content-center text-center border-b-[1px]">
                 <h2 class="font-bold text-2xl underline">{title}</h2>
                 <p>
                     <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
@@ -66,7 +66,7 @@ pub fn page(props: &BlogPostProps) -> Html {
                     <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>
                 </p>
             </div>
-            <div class="p-4">
+            <div class="flex flex-col py-4 items-center">
                 {Renderer::new().run(nodes)}
             </div>
         </>

--- a/website/src/pages/blog_post.rs
+++ b/website/src/pages/blog_post.rs
@@ -1,9 +1,25 @@
 use gloo_net::http::Request;
-use markdown::{structs::blog::BlogId, translate::node::RenderNode};
-use yew::{function_component, html, use_context, use_state, Html, Properties, UseStateHandle};
+use markdown::{
+    structs::{
+        blog::BlogId,
+        metadata::BlogMetadata,
+        tag::{TagId, TagMetadata},
+    },
+    translate::node::RenderNode,
+};
+use yew::{
+    function_component, html, html_nested, use_context, use_state, Html, Properties, UseStateHandle,
+};
 use yew_hooks::use_effect_once;
 
-use crate::{components::head::Head, context::BlogContext, render::Renderer};
+use crate::{
+    components::{
+        blog::{tag::Tag, to_read_time},
+        head::Head,
+    },
+    context::BlogContext,
+    render::Renderer,
+};
 
 #[derive(PartialEq, Properties)]
 pub struct BlogPostProps {
@@ -38,7 +54,12 @@ pub fn page(props: &BlogPostProps) -> Html {
         });
     }
 
-    let title = &blog_context.content[&props.blog_id].front_matter.title;
+    let BlogMetadata {
+        front_matter,
+        post_translate,
+    } = &blog_context.content[&props.blog_id];
+
+    let title = &front_matter.title;
     let nodes = ron::from_str::<Vec<RenderNode>>(&content).unwrap_or_default();
 
     html! {
@@ -46,7 +67,17 @@ pub fn page(props: &BlogPostProps) -> Html {
             <Head>
                 <title>{format!("{} | Hanyuan's Website", title)}</title>
             </Head>
-            {Renderer::new().run(nodes)}
+            <div class="w-full p-4 content-center text-center border-b-[1px]">
+                <h2 class="font-bold text-2xl underline">{title}</h2>
+                <p>
+                    <span class="text-gray-500">{&front_matter.publish_date.format("%d %b %Y").to_string()}</span>
+                    <span class="px-1 text-white">{"·"}</span>
+                    <span class="text-gray-500">{&to_read_time(post_translate.words)}</span>
+                </p>
+            </div>
+            <div class="p-4">
+                {Renderer::new().run(nodes)}
+            </div>
         </>
     }
 }

--- a/website/src/pages/blog_post.rs
+++ b/website/src/pages/blog_post.rs
@@ -1,22 +1,13 @@
 use gloo_net::http::Request;
 use markdown::{
-    structs::{
-        blog::BlogId,
-        metadata::BlogMetadata,
-        tag::{TagId, TagMetadata},
-    },
+    structs::{blog::BlogId, metadata::BlogMetadata},
     translate::node::RenderNode,
 };
-use yew::{
-    function_component, html, html_nested, use_context, use_state, Html, Properties, UseStateHandle,
-};
+use yew::{function_component, html, use_context, use_state, Html, Properties, UseStateHandle};
 use yew_hooks::use_effect_once;
 
 use crate::{
-    components::{
-        blog::{tag::Tag, to_read_time},
-        head::Head,
-    },
+    components::{blog::to_read_time, head::Head},
     context::BlogContext,
     render::Renderer,
 };

--- a/website/src/pages/home.rs
+++ b/website/src/pages/home.rs
@@ -6,7 +6,7 @@ use crate::components::{
     home::typewriter::{Block, Typewriter},
 };
 
-const INTRO_BLOCKS: [Block; 3] = [
+const INTRO_BLOCKS: [Block; 4] = [
     Block {
         // We need Unicode escape here (equivalent to "&nbsp;") since Yew
         // does not allow for us to do <p>&nbsp;</p> by itself
@@ -21,6 +21,11 @@ const INTRO_BLOCKS: [Block; 3] = [
         text: ".",
         class: "font-bold text-3xl",
     },
+    Block {
+        // Simulate the blinking cursor effect
+        text: ".",
+        class: "text-3xl text-white text-opacity-0 animate-blink"
+    }
 ];
 
 #[function_component(Page)]
@@ -52,13 +57,15 @@ pub fn page() -> Html {
                                 })} />
                         </div>
                         <div class={format!("{} {}", "flex flex-row justify-center transition duration-500", opacity)}>
-                            <p>{"I am a final-year Advanced Computer Science student at\u{00a0}"}</p>
-                            <a
-                                class="text-green underline transition hover:bg-gray"
-                                href="https://www.unsw.edu.au/engineering/our-schools/computer-science-and-engineering">
-                                {"UNSW"}
-                            </a>
-                            <p>{"."}</p>
+                            <p>
+                                {"I am a final-year Advanced Computer Science student at\u{00a0}"}
+                                <a
+                                    class="text-green underline transition hover:bg-gray"
+                                    href="https://www.unsw.edu.au/engineering/our-schools/computer-science-and-engineering">
+                                    {"UNSW"}
+                                </a>
+                                {"."}
+                            </p>
                         </div>
                     </div>
                 </div>

--- a/website/src/render.rs
+++ b/website/src/render.rs
@@ -41,7 +41,7 @@ impl Renderer {
         }
 
         let prose = html! {
-            <article class="prose dark:prose-invert">
+            <article class="prose dark:prose-invert max-w-none">
                 {self.prose.clone()}
             </article>
         };

--- a/website/src/render.rs
+++ b/website/src/render.rs
@@ -41,7 +41,7 @@ impl Renderer {
         }
 
         let prose = html! {
-            <article class="prose dark:prose-invert max-w-none">
+            <article class="prose dark:prose-invert">
                 {self.prose.clone()}
             </article>
         };


### PR DESCRIPTION
Previously, the website was laptop-only, which is not great for a site primarily focused around blogs. This PR fixes that issue by:
- Styling elements of each page to support both mobile and laptop at the same time
- Failing that, adding extra support for mobile (e.g. hamburger menu in header)

This PR also modifies blog posts slightly, adding a title and removing the original width limit.