### PR TITLE
FEATURE: publish site from `gh-pages` branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - feature/gh-pages-branch
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
Change `.github/deploy.yml` to now upload files to the `gh-pages` branch instead of creating artifacts.

This is the first step towards supporting a `staging` environment - you can now simply create a `staging` folder, and place any staging files there.